### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <revision>2.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.